### PR TITLE
chore: centralize aws credentials action wrapper

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ runs:
         which cdktf
         cdktf --version
     - name: Assume role using OIDC
-      uses: aws-actions/configure-aws-credentials@v6.0.0
+      uses: p6m7g8-actions/aws-credentials@main
       with:
         aws-region: ${{ inputs.aws_region }}
         role-to-assume: ${{ inputs.aws_role }}


### PR DESCRIPTION
## Summary
- replace direct use of aws-actions/configure-aws-credentials
- use p6m7g8-actions/aws-credentials@main wrapper

## Testing
- yamllint action.yml (warnings only; consistent with existing repo lint baseline)